### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/andrewmin0240/55eaed97-7a39-446b-ae69-a71fadbe967c/99a994a1-5f16-4765-9d94-b9cda87c83dd/_apis/work/boardbadge/e72ba0cb-465a-49fc-b7c6-3842cfb713ed)](https://dev.azure.com/andrewmin0240/55eaed97-7a39-446b-ae69-a71fadbe967c/_boards/board/t/99a994a1-5f16-4765-9d94-b9cda87c83dd/Microsoft.RequirementCategory)
 # Spring Microservice Petclinic on AKS
 
 ## 필요도구


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#39](https://dev.azure.com/andrewmin0240/55eaed97-7a39-446b-ae69-a71fadbe967c/_workitems/edit/39). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.